### PR TITLE
Changed Apriori to only generate connected frequent subgraphs

### DIFF
--- a/Apriori_Node.py
+++ b/Apriori_Node.py
@@ -121,7 +121,7 @@ def generate_candidates(freq_subgraphs):
                             break
 
                     #  Add candidate only if it is not already generated
-                    if not candidate_already_generated:    
+                    if not candidate_already_generated and nx.is_connected(new_candidate):    
                         candidates.add(new_candidate)
                         #debug_print("candidate found")
         print(f"\rGenerated with graph {i}/{len(freq_subgraphs_list)}...", end="")
@@ -150,6 +150,8 @@ def all_subgraphs_frequent(candidate, freq_subgraphs):
     for node in candidate.nodes():
         sub_of_candidate = nx.Graph(candidate)
         sub_of_candidate.remove_node(node)
+        if nx.is_connected(sub_of_candidate) is False:
+            continue
         sub_of_candidate_frequent = False
         for subgraph in freq_subgraphs:
             ullman = UllmanAlgorithm(subgraph, sub_of_candidate)


### PR DESCRIPTION
This pull request improves the Apriori algorithm's implementation by ensuring that only connected subgraphs and candidates are considered during graph generation and frequency checks. These changes enhance the algorithm's correctness and efficiency.

### Enhancements to candidate generation and frequency checks:

* `Apriori_Node.py`:
  - In `generate_candidates`: Added a check to ensure that only connected candidates are added to the `candidates` set. (`[Apriori_Node.pyL124-R124](diffhunk://#diff-c3d912c8ab7cc8e55a1186363d6c43d8cc92f047fd3c86080f3056004f53f388L124-R124)`)
  - In `all_subgraphs_frequent`: Added a condition to skip subgraphs that are not connected when verifying if all subgraphs of a candidate are frequent. (`[Apriori_Node.pyR153-R154](diffhunk://#diff-c3d912c8ab7cc8e55a1186363d6c43d8cc92f047fd3c86080f3056004f53f388R153-R154)`)